### PR TITLE
Allow to specify unbound number of persistence urls

### DIFF
--- a/_resources/config/example.toml
+++ b/_resources/config/example.toml
@@ -5,6 +5,27 @@
 "docker_registry" = "https://docker.example.com" # can be overridden with the env var DOCKER_REGISTRY.
 "sdk_path" = "github.com/adevinta/vulcan-check-sdk"
 "vulcan_checks_repo" = "vulcan-checks"
-"persistence_pro" = "https://vulcan-persistence.example.com"
-"persistence_pre" = "https://vulcan-persistence-pre.example.com"
-"persistence_dev" = "https://vulcan-persistence-dev.example.com"
+
+# Defines the url's of the persistence envs that the checks need to be
+# published to when a commit is made to the master branch of the checks
+# repository. If publishing any of these envs fails the build system with fail
+# the operation. 
+"primary_master_branch_envs" = ["https://vulcan-persistence-dev.example.com"]
+
+# Defines the url's of the persistence envs that the checks need to be
+# published to when a commit is made to the master branch of the checks
+# repository. If publishing any of these envs fails, the build system will not
+# fail the operation but just print a warning to the stdout.
+"secondary_master_branch_envs" = []
+
+# Defines the url's of the persistence envs that the checks need to be
+# published to when a commit is made any branch of the checks repository.
+# If publishing any of these envs fails, the build system with fail
+# the operation.
+"primary_dev_branch_envs" = ["https://vulcan-persistence.example.com","https://vulcan-persistence-pre.example.com"]
+
+# Defines the url's of the persistence envs that the checks need to be
+# published to when a commit is made any branch of the checks repository.
+# If publishing any of these envs fails, the build system will not
+# fail the operation but just print a warning to the stdout.
+"secondary_dev_branch_envs" = ["https://vulcan-persistence.example.com","https://vulcan-persistence-pre.example.com"]

--- a/cmd/vulcan-build-images/main_test.go
+++ b/cmd/vulcan-build-images/main_test.go
@@ -71,6 +71,7 @@ func Test_pubChecktypeToPersistence(t *testing.T) {
 		checkName string
 		metadata  manifest.Data
 		imagePath string
+		fail      bool
 	}
 	tests := []struct {
 		name              string
@@ -80,14 +81,26 @@ func Test_pubChecktypeToPersistence(t *testing.T) {
 		wantErr           bool
 	}{
 		{
-			name: "HappyPath",
+			name: "HappyPathFail",
 			args: args{
 				checkName: "check",
-				imagePath: "docker.schibsted.io/check:2",
+				imagePath: "docker.example.com/check:2",
 				metadata:  manifest.Data{},
+				fail:      true,
 			},
 			apiResponse:       "{\"properties\":{\"docker.label.commit\": [\"01234a\"],\"docker.label.sdk-version\": [\"8e938a5\"]}}",
 			persistenceStatus: http.StatusCreated,
+		},
+		{
+			name: "HappyPathNoFail",
+			args: args{
+				checkName: "check",
+				imagePath: "docker.example.com/check:2",
+				metadata:  manifest.Data{},
+				fail:      false,
+			},
+			apiResponse:       "{\"properties\":{\"docker.label.commit\": [\"01234a\"],\"docker.label.sdk-version\": [\"8e938a5\"]}}",
+			persistenceStatus: http.StatusInternalServerError,
 		},
 	}
 	for _, tt := range tests {
@@ -95,7 +108,7 @@ func Test_pubChecktypeToPersistence(t *testing.T) {
 			tt := tt
 			s := buildFakePersistence(tt.apiResponse, tt.persistenceStatus)
 			defer s.Close()
-			if err := pubChecktypeToPersistence(tt.args.checkName, tt.args.metadata, tt.args.imagePath, s.URL); (err != nil) != tt.wantErr {
+			if err := pubChecktypeToPersistence(tt.args.checkName, tt.args.metadata, tt.args.imagePath, tt.args.fail, s.URL); (err != nil) != tt.wantErr {
 				t.Errorf("pubChecktypeToPersistence() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,12 @@ type Config struct {
 	SDKPath                  string `toml:"docker_sdk_path"`
 	DockerRegistry           string `toml:"docker_registry_pwd"`
 	VulcanChecksRepo         string `toml:"vulcan_checks_repo"`
-	PersistencePro           string `toml:"persistence_pro"`
-	PersistencePre           string `toml:"persistence_pre"`
-	PersistenceDev           string `toml:"persistence_dev"`
+
+	PrimaryMasterBranchEnvs   []string `toml:"primary_master_branch_envs"`
+	SecondaryMasterBranchEnvs []string `toml:"secondary_master_branch_envs"`
+
+	PrimaryDevBranchEnvs   []string `toml:"primary_dev_branch_envs"`
+	SecondaryDevBranchEnvs []string `toml:"secondary_dev_branch_envs"`
 }
 
 // LoadFrom loads the config from the specified file path.


### PR DESCRIPTION
This PR modifies the configuration file format to accept a variable number of vulcan persistence services url's. Concretely, the new format has two new parameters which are arrays of strings: 

- "persistence_master_branch_envs" define the url's of the vulcan-persistence where the checks should be published to when a commit is merger into master. 

- "persistence_dev_branch_envs" define the url's of the vulcan-persistence where the checks should be published to when a commit is merger in a branch that is not master.