### PR TITLE
Fix bug in publishing secondary master

### DIFF
--- a/cmd/vulcan-build-images/main.go
+++ b/cmd/vulcan-build-images/main.go
@@ -384,7 +384,7 @@ func pushImagesAndChecktypes(imagesToPush []checkImageInfo) error {
 			primaryEnvs := append(config.Cfg.PrimaryMasterBranchEnvs, config.Cfg.PrimaryDevBranchEnvs...)
 			err = pubChecktypeToPersistence(i.checktypeName, i.manifest, i.imageName, true, primaryEnvs...)
 			if err == nil {
-				secondaryEnvs := append(config.Cfg.PrimaryMasterBranchEnvs, config.Cfg.SecondaryDevBranchEnvs...)
+				secondaryEnvs := append(config.Cfg.SecondaryMasterBranchEnvs, config.Cfg.SecondaryDevBranchEnvs...)
 				err = pubChecktypeToPersistence(i.checktypeName, i.manifest, i.imageName, false, secondaryEnvs...)
 			}
 		}


### PR DESCRIPTION
This PR fixes a bug when publishing the a check to the secondary master persistence environments.