### PR TITLE
Fix FetchImagesInfo bug in url generation

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -405,9 +405,8 @@ func FetchImageTagInfo(image string, tag string) (ImageVersionInfo, error) {
 	restyClient := resty.New()
 	client := restyClient.SetHostURL(config.Cfg.DockerAPIBaseExtendedURL)
 	setupAPICred(client)
-	tagsPath := fmt.Sprintf("%s/%s/%s/manifest.json?properties", config.Cfg.VulcanChecksRepo, image, tag)
+	tagsPath := fmt.Sprintf("%s/%s/manifest.json?properties", image, tag)
 	r := client.R()
-
 	response, err := r.Get(tagsPath)
 	if err != nil {
 		return result, err
@@ -433,7 +432,6 @@ func FetchImageTagInfo(image string, tag string) (ImageVersionInfo, error) {
 	if err != nil {
 		return result, err
 	}
-
 	commits, exists := payload.Properties["docker.label.commit"]
 	if !exists {
 		// NOTE: consider using Logger.


### PR DESCRIPTION
This PR fixes a bug in the code that was preventing to build properly the url for fetching the information of a docker image from a registry. That bug was causing the command vulcan-detect-images to work properly.