### PR TITLE
Inject required vars when running check locally

### DIFF
--- a/cmd/vulcan-build-images/main.go
+++ b/cmd/vulcan-build-images/main.go
@@ -424,6 +424,10 @@ func forceRun(imagePath string) error {
 		env = append(env, "VULCAN_CHECK_TARGET="+c.Check.Target)
 		env = append(env, "VULCAN_CHECK_OPTIONS="+c.Check.Opts)
 		env = append(env, "VULCAN_ALLOW_PRIVATE_IPS="+strconv.FormatBool(allowPrivateIPs))
+
+		for k, v := range c.RequiredVars {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 	return util.RunCheckImage(imageName, env)
 }


### PR DESCRIPTION
This PR adds the code necessary to inject required env vars when using the -r flag of the vulcan-build-images script.