### PR TITLE
Add support for GCPProject asset type

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -33,6 +33,8 @@ const (
 	WebAddress
 	// GitRepository represents a git repo asset type.
 	GitRepository
+	// GCPProject represents a GCP Project type.
+	GCPProject
 )
 
 var assetTypeStrings = map[AssetType]string{
@@ -44,6 +46,7 @@ var assetTypeStrings = map[AssetType]string{
 	DockerImage:   "DockerImage",
 	WebAddress:    "WebAddress",
 	GitRepository: "GitRepository",
+	GCPProject:    "GCPProject",
 }
 
 // MarshalText returns string representation of a AssetType instance.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -33,7 +33,7 @@ const (
 	WebAddress
 	// GitRepository represents a git repo asset type.
 	GitRepository
-	// GCPProject represents a GCP Project type.
+	// GCPProject represents a GCP Project asset type.
 	GCPProject
 )
 


### PR DESCRIPTION
This change aims to add support for `GCPProject` asset type for building the checks for scanning GCP Project.